### PR TITLE
Add explicit cuda support

### DIFF
--- a/farm.py
+++ b/farm.py
@@ -11,7 +11,7 @@ import torch
 if torch.cuda.is_available():
 	model = YOLO("best.pt").to('cuda')
 else:
-	model = YOLO("best.pt").to(device)
+	model = YOLO("best.pt")
 
 
 screen_width, screen_height = pyautogui.size()

--- a/farm.py
+++ b/farm.py
@@ -8,9 +8,11 @@ import win32gui
 import win32con
 import torch
 
-device = 'cuda' if torch.cuda.is_available() else 'cpu'
+if torch.cuda.is_available():
+	model = YOLO("best.pt").to('cuda')
+else:
+	model = YOLO("best.pt").to(device)
 
-model = YOLO("best.pt").to(device)
 
 screen_width, screen_height = pyautogui.size()
 center_x, center_y = screen_width // 2, screen_height // 2

--- a/farm.py
+++ b/farm.py
@@ -6,8 +6,11 @@ import numpy as np
 import mouse
 import win32gui
 import win32con
+import torch
 
-model = YOLO("best.pt")
+device = 'cuda' if torch.cuda.is_available() else 'cpu'
+
+model = YOLO("best.pt").to(device)
 
 screen_width, screen_height = pyautogui.size()
 center_x, center_y = screen_width // 2, screen_height // 2


### PR DESCRIPTION
This PR fixes https://github.com/MotyaV/BlumAiFarm/issues/2

I tried running this model on my GTX 1060 and had a few clicks only,

[This comment](https://github.com/ultralytics/ultralytics/issues/3084#issuecomment-1806617276) says that YOLO can support CUDA

So in order to run this model on older devices you have to explicitly use CUDA and install it before running the model:
1) Install CUDA 12.1
2) Install torchvision and related stuff with CUDA 12.1 like this:
`pip install torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cu121`

Quick test shows almost 200 clicks